### PR TITLE
fix: accept standard browserstack environment variables

### DIFF
--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -53,7 +53,9 @@ class CliRunner {
     let rendered = ejs.render(tplData, {
       plugins: (availablePlugins.length > 0) ? JSON.stringify(availablePlugins) : '[]',
       launch_url,
-      isMacOS: os.platform() === 'darwin'
+      isMacOS: os.platform() === 'darwin',
+      browserstackUserName: process.env.BROWSERSTACK_USERNAME ? '${BROWSERSTACK_USERNAME}' : '${BROWSERSTACK_USER}',
+      browserstackAccessKey: process.env.BROWSERSTACK_ACCESS_KEY ? '${BROWSERSTACK_ACCESS_KEY}' : '${BROWSERSTACK_KEY}',
     });
 
     rendered = Utils.stripControlChars(rendered);

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -55,7 +55,7 @@ class CliRunner {
       launch_url,
       isMacOS: os.platform() === 'darwin',
       browserstackUserName: process.env.BROWSERSTACK_USERNAME ? '${BROWSERSTACK_USERNAME}' : '${BROWSERSTACK_USER}',
-      browserstackAccessKey: process.env.BROWSERSTACK_ACCESS_KEY ? '${BROWSERSTACK_ACCESS_KEY}' : '${BROWSERSTACK_KEY}',
+      browserstackAccessKey: process.env.BROWSERSTACK_ACCESS_KEY ? '${BROWSERSTACK_ACCESS_KEY}' : '${BROWSERSTACK_KEY}'
     });
 
     rendered = Utils.stripControlChars(rendered);

--- a/lib/runner/cli/nightwatch.conf.ejs
+++ b/lib/runner/cli/nightwatch.conf.ejs
@@ -171,8 +171,8 @@ module.exports = {
     // Configuration for when using the browserstack.com cloud service               |
     //                                                                               |
     // Please set the username and access key by setting the environment variables:  |
-    // - BROWSERSTACK_USER                                                           |
-    // - BROWSERSTACK_KEY                                                            |
+    // - BROWSERSTACK_USER or BROWSERSTACK_USERNAME                                  |
+    // - BROWSERSTACK_KEY or BROWSERSTACK_ACCESS_KEY                                 |
     // .env files are supported                                                      |
     //////////////////////////////////////////////////////////////////////////////////
     browserstack: {
@@ -184,8 +184,8 @@ module.exports = {
       // https://www.browserstack.com/automate/capabilities?tag=selenium-4
       desiredCapabilities: {
         'bstack:options' : {
-          userName: '${BROWSERSTACK_USER}',
-          accessKey: '${BROWSERSTACK_KEY}',
+          userName: '<%- browserstackUserName %>',
+          accessKey: '<%- browserstackAccessKey %>',
         }
       },
 

--- a/lib/transport/selenium-webdriver/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack.js
@@ -8,15 +8,32 @@ class Browserstack extends Selenium {
   }
 
   get accessKey() {
-    return this.settings.desiredCapabilities['browserstack.key'];
+    return this.settings.desiredCapabilities['bstack:options'] &&
+      this.settings.desiredCapabilities['bstack:options'].accessKey
+      ? this.settings.desiredCapabilities['bstack:options'].accessKey
+      : this.settings.desiredCapabilities['browserstack.key'];
+
   }
 
   get username() {
-    return this.settings.desiredCapabilities['browserstack.user'];
+    return this.settings.desiredCapabilities['bstack:options'] &&
+      this.settings.desiredCapabilities['bstack:options'].userName
+      ? this.settings.desiredCapabilities['bstack:options'].userName
+      : this.settings.desiredCapabilities['browserstack.user'];
   }
 
   get build() {
-    return this.settings.desiredCapabilities.build;
+    return this.settings.desiredCapabilities['bstack:options'] &&
+      this.settings.desiredCapabilities['bstack:options'].buildName
+      ? this.settings.desiredCapabilities['bstack:options'].buildName
+      : this.settings.desiredCapabilities.build;
+  }
+
+  get local() {
+    return this.settings.desiredCapabilities['bstack:options'] &&
+      this.settings.desiredCapabilities['bstack:options'].local
+      ? this.settings.desiredCapabilities['bstack:options'].local
+      : this.settings.desiredCapabilities['browserstack.local'];
   }
 
   constructor(nightwatchInstance, browserName) {
@@ -41,19 +58,25 @@ class Browserstack extends Selenium {
     this.settings.webdriver.start_process = false;
     this.settings.webdriver.port = Number(this.settings.webdriver.port);
 
-    if (!this.accessKey && process.env.BROWSERSTACK_KEY) {
-      this.settings.desiredCapabilities['browserstack.key'] = process.env.BROWSERSTACK_KEY;
+    const browserstackKey = process.env.BROWSERSTACK_ACCESS_KEY ?
+      process.env.BROWSERSTACK_ACCESS_KEY :
+      process.env.BROWSERSTACK_KEY;
+    if (!this.accessKey && browserstackKey) {
+      this.settings.desiredCapabilities['browserstack.key'] = browserstackKey;
     }
 
-    if (!this.username && process.env.BROWSERSTACK_USER) {
-      this.settings.desiredCapabilities['browserstack.user'] = process.env.BROWSERSTACK_USER;
+    const browserstackUsername = process.env.BROWSERSTACK_USERNAME ?
+      process.env.BROWSERSTACK_USERNAME :
+      process.env.BROWSERSTACK_USER;
+    if (!this.username && browserstackUsername) {
+      this.settings.desiredCapabilities['browserstack.user'] = browserstackUsername;
     }
 
     if (!this.build) {
       this.settings.desiredCapabilities.build = 'nightwatch-test-build';
     }
 
-    if (this.settings.desiredCapabilities['browserstack.local']) {
+    if (this.local) {
       this.useLocal = true;
     }
   }
@@ -67,12 +90,12 @@ class Browserstack extends Selenium {
 
     if (!this.accessKey) {
       throw new Error('BrowserStack access key is not set. Verify that "browserstack.key" capability is set correctly or ' +
-        'set BROWSERSTACK_KEY environment variable (.env files are supported).');
+        'set BROWSERSTACK_KEY (or BROWSERSTACK_ACCESS_KEY) environment variable (.env files are supported).');
     }
 
     if (!this.username) {
       throw new Error('BrowserStack username is not set. Verify that "browserstack.user" capability is set correctly or ' +
-        'set BROWSERSTACK_USER environment variable (.env files are supported).');
+        'set BROWSERSTACK_USER (or BROWSERSTACK_USERNAME) environment variable (.env files are supported).');
     }
   }
 

--- a/test/src/index/transport/testBrowserstackTransport.js
+++ b/test/src/index/transport/testBrowserstackTransport.js
@@ -25,7 +25,7 @@ describe('BrowserstackTransport', function () {
           port: 443
         }
       });
-    }, /BrowserStack access key is not set\. Verify that "browserstack\.key" capability is set correctly or set BROWSERSTACK_KEY environment variable \(\.env files are supported\)\./);
+    }, /BrowserStack access key is not set\. Verify that "browserstack\.key" capability is set correctly or set BROWSERSTACK_KEY \(or BROWSERSTACK_ACCESS_KEY\) environment variable \(\.env files are supported\)\./);
 
     assert.throws(function() {
       NightwatchClient.client({
@@ -37,7 +37,7 @@ describe('BrowserstackTransport', function () {
           'browserstack.key': 'test-access-key'
         }
       });
-    }, /BrowserStack username is not set\. Verify that "browserstack\.user" capability is set correctly or set BROWSERSTACK_USER environment variable \(\.env files are supported\)\./);
+    }, /BrowserStack username is not set\. Verify that "browserstack\.user" capability is set correctly or set BROWSERSTACK_USER \(or BROWSERSTACK_USERNAME\) environment variable \(\.env files are supported\)\./);
 
   });
 


### PR DESCRIPTION
BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY are the env variables specified in docs, check for these. Also accept buildName, local if sent inside 'bstack:options'

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
